### PR TITLE
Icon fix windows

### DIFF
--- a/RootPainter3D.nsi
+++ b/RootPainter3D.nsi
@@ -113,16 +113,6 @@ Section -Icons_Reg
 SetOutPath "$INSTDIR"
 WriteUninstaller "$INSTDIR\uninstall.exe"
 
-!ifdef REG_START_MENU
-!insertmacro MUI_STARTMENU_WRITE_BEGIN Application
-CreateDirectory "$SMPROGRAMS\$SM_Folder"
-CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\painter\icons\icon.ico" 0
-CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\painter\icons\icon.ico" 0
-CreateShortCut "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe"
-
-!insertmacro MUI_STARTMENU_WRITE_END
-!endif
-
 # define the output path for this file
 SetOutPath $INSTDIR
 
@@ -139,6 +129,16 @@ CreateDirectory $INSTDIR
 # PACKAGE ENTIRE CONTENT OF BUNDLE THE NEW BINARY!
 File /nonfatal /a /r ".\dist\RootPainter3D\*"
 ExecWait "$INSTDIR\RootPainter3D-installed.exe"
+
+!ifdef REG_START_MENU
+!insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+CreateDirectory "$SMPROGRAMS\$SM_Folder"
+CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\painter\icons\icon.ico" 0
+CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\painter\icons\icon.ico" 0
+CreateShortCut "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe"
+
+!insertmacro MUI_STARTMENU_WRITE_END
+!endif
 
 # default section end
 SectionEnd

--- a/RootPainter3D.nsi
+++ b/RootPainter3D.nsi
@@ -133,8 +133,8 @@ ExecWait "$INSTDIR\RootPainter3D-installed.exe"
 !ifdef REG_START_MENU
 !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
 CreateDirectory "$SMPROGRAMS\$SM_Folder"
-CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\painter\icons\icon.ico" 0
-CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\painter\icons\icon.ico" 0
+CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}"
+CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}"
 CreateShortCut "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe"
 
 !insertmacro MUI_STARTMENU_WRITE_END


### PR DESCRIPTION
After installing the software through the binary installer on Windows, you will find that the icon is not showing.

However, if you restart the machine, the icon will show.

This is because during installation, we are creating the shortcuts before the icons are written to disk, which means that the icons are not available.

However, when restarting, Windows will refetch the icons, which is why the icon now will show.

The fix was basically to change the installation order in the .nsi file. Quite easy to do, but was challenging to debug. However, I found the same issue in a related software, [Raidionics](https://github.com/dbouget/Raidionics/pull/16).

I also found that setting the icons for the shortcut is not necessary, as modern NSIS will find the correct icon dynamically by using the icon of the executable.